### PR TITLE
Load schedule from JSON

### DIFF
--- a/app/src/main/java/hacktx/hacktx2015/activities/BaseActivity.java
+++ b/app/src/main/java/hacktx/hacktx2015/activities/BaseActivity.java
@@ -80,6 +80,7 @@ public abstract class BaseActivity extends AppCompatActivity {
                                         if(navSelect != 0) {
                                             Intent intent = new Intent(context, MainActivity.class);
                                             intent.putExtra("navSelect", 0);
+                                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                                             startActivity(intent);
                                         }
                                     }
@@ -92,6 +93,7 @@ public abstract class BaseActivity extends AppCompatActivity {
                                         if(navSelect != 1) {
                                             Intent intent = new Intent(context, AnnouncementsActivity.class);
                                             intent.putExtra("navSelect", 1);
+                                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                                             startActivity(intent);
                                         }
                                     }
@@ -104,6 +106,7 @@ public abstract class BaseActivity extends AppCompatActivity {
                                         if(navSelect != 2) {
                                             Intent intent = new Intent(context, TwitterActivity.class);
                                             intent.putExtra("navSelect", 2);
+                                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                                             startActivity(intent);
                                         }
                                     }
@@ -128,6 +131,7 @@ public abstract class BaseActivity extends AppCompatActivity {
                                         if(navSelect != 4) {
                                             Intent intent = new Intent(context, SponsorActivity.class);
                                             intent.putExtra("navSelect", 4);
+                                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                                             startActivity(intent);
                                         }
                                     }

--- a/app/src/main/java/hacktx/hacktx2015/activities/BaseActivity.java
+++ b/app/src/main/java/hacktx/hacktx2015/activities/BaseActivity.java
@@ -1,23 +1,20 @@
 package hacktx.hacktx2015.activities;
 
+import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.design.widget.NavigationView;
-import android.support.design.widget.TabLayout;
 import android.support.v4.view.GravityCompat;
-import android.support.v4.view.ViewPager;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
-import android.view.Menu;
 import android.view.MenuItem;
-
-import java.util.ArrayList;
 
 import hacktx.hacktx2015.R;
 
@@ -32,6 +29,14 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            String appName = getString(R.string.app_name);
+            Bitmap icon = BitmapFactory.decodeResource(getResources(), R.mipmap.ic_launcher);
+            int color = getResources().getColor(R.color.primaryDark);
+            ActivityManager.TaskDescription taskDesc = new ActivityManager.TaskDescription(appName, icon, color);
+            setTaskDescription(taskDesc);
+        }
     }
 
     @Override

--- a/app/src/main/java/hacktx/hacktx2015/fragments/ScheduleDayFragment.java
+++ b/app/src/main/java/hacktx/hacktx2015/fragments/ScheduleDayFragment.java
@@ -1,11 +1,11 @@
 package hacktx.hacktx2015.fragments;
 
 import android.app.ProgressDialog;
-import android.content.DialogInterface;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -45,10 +45,12 @@ import hacktx.hacktx2015.views.adapters.ScheduleClusterRecyclerView;
  */
 public class ScheduleDayFragment extends Fragment {
 
+    private RecyclerView recyclerView;
+    private SwipeRefreshLayout swipeRefreshLayout;
     private ArrayList<ScheduleCluster> scheduleList;
-    RecyclerView recyclerView;
 
-    public ScheduleDayFragment() {}
+    public ScheduleDayFragment() {
+    }
 
     public static ScheduleDayFragment newInstance(String request) {
 
@@ -65,6 +67,17 @@ public class ScheduleDayFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.fragment_schedule_day, container, false);
         scheduleList = new ArrayList<>();
+
+        swipeRefreshLayout = (SwipeRefreshLayout) root.findViewById(R.id.swipeRefreshLayout);
+        swipeRefreshLayout.setColorSchemeResources(R.color.primary, R.color.accent);
+        swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                scheduleList.clear();
+                new ScheduleDataAsyncTask().execute();
+            }
+        });
+
         new ScheduleDataAsyncTask().execute();
 
         recyclerView = (RecyclerView) root.findViewById(R.id.scheduleRecyclerView);
@@ -78,17 +91,11 @@ public class ScheduleDayFragment extends Fragment {
 
     class ScheduleDataAsyncTask extends AsyncTask<String, String, Void> {
 
-        private ProgressDialog progressDialog = new ProgressDialog(getActivity());
         JSONArray jsonArray = null;
+        private ProgressDialog progressDialog = new ProgressDialog(getActivity());
 
         protected void onPreExecute() {
-            progressDialog.setMessage("Getting schedule...");
-            progressDialog.show();
-            progressDialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
-                public void onCancel(DialogInterface arg0) {
-                    cancel(true);
-                }
-            });
+            swipeRefreshLayout.setRefreshing(true);
         }
 
         @Override
@@ -190,7 +197,7 @@ public class ScheduleDayFragment extends Fragment {
             RecyclerView.Adapter scheduleAdapter = new ScheduleClusterRecyclerView(scheduleList);
             recyclerView.setAdapter(scheduleAdapter);
 
-            progressDialog.dismiss();
+            swipeRefreshLayout.setRefreshing(false);
         }
     }
 }

--- a/app/src/main/java/hacktx/hacktx2015/fragments/ScheduleDayFragment.java
+++ b/app/src/main/java/hacktx/hacktx2015/fragments/ScheduleDayFragment.java
@@ -153,7 +153,7 @@ public class ScheduleDayFragment extends Fragment {
                     ArrayList<ScheduleEvent> events = new ArrayList<>();
 
                     for (int n = 0; n < eventsArrayJson.length(); n++) {
-                        JSONObject event = eventsArrayJson.getJSONObject(x);
+                        JSONObject event = eventsArrayJson.getJSONObject(n);
                         EventType type;
                         switch (event.getString("type")) {
                             case "food":

--- a/app/src/main/java/hacktx/hacktx2015/fragments/ScheduleDayFragment.java
+++ b/app/src/main/java/hacktx/hacktx2015/fragments/ScheduleDayFragment.java
@@ -8,29 +8,24 @@ import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
 
 import hacktx.hacktx2015.R;
@@ -102,43 +97,29 @@ public class ScheduleDayFragment extends Fragment {
         protected Void doInBackground(String... params) {
 
             String url = "http://texasgamer.me/projects/hacktx/schedule.json";
-            InputStream is = null;
-            String json = "";
 
             try {
-                DefaultHttpClient httpClient = new DefaultHttpClient();
-                HttpPost httpPost = new HttpPost(url);
+                URL u = new URL(url);
+                HttpURLConnection httpURLConnection = (HttpURLConnection) u.openConnection();
+                httpURLConnection.setRequestMethod("GET");
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(httpURLConnection.getInputStream()));
+                StringBuilder stringBuilder = new StringBuilder();
 
-                HttpResponse httpResponse = httpClient.execute(httpPost);
-                HttpEntity httpEntity = httpResponse.getEntity();
-                is = httpEntity.getContent();
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    stringBuilder.append(line + '\n');
+                }
 
-            } catch (UnsupportedEncodingException e) {
+                jsonArray = new JSONArray(stringBuilder.toString());
+                httpURLConnection.disconnect();
+            } catch (MalformedURLException e) {
                 e.printStackTrace();
-            } catch (ClientProtocolException e) {
+            } catch (ProtocolException e) {
                 e.printStackTrace();
             } catch (IOException e) {
                 e.printStackTrace();
-            }
-
-            try {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(
-                        is, "iso-8859-1"), 8);
-                StringBuilder sb = new StringBuilder();
-                String line = null;
-                while ((line = reader.readLine()) != null) {
-                    sb.append(line + "\n");
-                }
-                is.close();
-                json = sb.toString();
-            } catch (Exception e) {
-                Log.e("Buffer Error", "Error converting result " + e.toString());
-            }
-
-            try {
-                jsonArray = new JSONArray(json);
             } catch (JSONException e) {
-                Log.e("JSON Parser", "Error parsing data " + e.toString());
+                e.printStackTrace();
             }
 
             return null;

--- a/app/src/main/java/hacktx/hacktx2015/fragments/ScheduleDayFragment.java
+++ b/app/src/main/java/hacktx/hacktx2015/fragments/ScheduleDayFragment.java
@@ -20,6 +20,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import hacktx.hacktx2015.R;
@@ -63,7 +65,6 @@ public class ScheduleDayFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.fragment_schedule_day, container, false);
         scheduleList = new ArrayList<>();
-        getFakeData();
         new ScheduleDataAsyncTask().execute();
 
         recyclerView = (RecyclerView) root.findViewById(R.id.scheduleRecyclerView);
@@ -75,67 +76,10 @@ public class ScheduleDayFragment extends Fragment {
         return root;
     }
 
-    private void getFakeData() {
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
-        ScheduleSpeaker batman = new ScheduleSpeaker(0,
-                "Batman",
-                "Justice Inc",
-                "Hero can be anyone. Even a man knowing something as simple and reassuring as putting a coat around a young boy shoulders to let him know the world hadn't ended.",
-                "http://cdn.bgr.com/2015/04/batman-v-superman-trailer.png");
-        ScheduleSpeaker superman = new ScheduleSpeaker(1,
-                "Superman",
-                "Peace Inc",
-                "You will travel far, my little Kal-El. But we will never leave you... even in the face of our death. The richness of our lives shall be yours. All that I have, all that I've learned, everything I feel... all this, and more, I... I bequeath you, my son. You will carry me inside you, all the days of your life. You will make my strength your own, and see my life through your eyes, as your life will be seen through mine. The son becomes the father, and the father the son. This is all I... all I can send you, Kal-El.",
-                "http://1.bp.blogspot.com/-w9vnmSGyhBU/VRL-ioqskHI/AAAAAAAAATA/WpM7LR8Pg1k/s1600/superman01.png");
-
-        ArrayList<ScheduleSpeaker> batmanList = new ArrayList<>();
-        batmanList.add(batman);
-        ArrayList<ScheduleSpeaker> supermanList = new ArrayList<>();
-        supermanList.add(superman);
-        ArrayList<ScheduleSpeaker> superAndBatList = new ArrayList<>();
-        batmanList.add(batman);
-        supermanList.add(superman);
-
-        try {
-            ScheduleEvent batman0 = new ScheduleEvent(0, EventType.TALK, "BatScript: The real dev language",
-                    formatter.parse("2015-09-26 08:00:00"),
-                    formatter.parse("2015-09-26 09:00:00"),
-                    "SAC Mainroom", "We be talkin about stuff", batmanList);
-            ScheduleEvent batman1 = new ScheduleEvent(1, EventType.EDUCATION, "BatPython: The gangsta dev language",
-                    formatter.parse("2015-09-26 08:00:00"),
-                    formatter.parse("2015-09-26 09:00:00"),
-                    "Blue Room", "We be talkin about stuff", batmanList);
-            ArrayList<ScheduleEvent> firstList = new ArrayList<>();
-            firstList.add(batman0);
-            firstList.add(batman1);
-            ScheduleCluster firstCluster = new ScheduleCluster(0, "8:00 AM", firstList);
-
-            ScheduleEvent superman0 = new ScheduleEvent(2, EventType.FOOD, "SuperJava: The caffinated dev language",
-                    formatter.parse("2015-09-26 09:00:00"),
-                    formatter.parse("2015-09-26 10:00:00"),
-                    "Taco Room", "We be talkin about stuff", supermanList);
-            ScheduleEvent superbat0 = new ScheduleEvent(3, EventType.FOOD, "V super much Bat: Food for all",
-                    formatter.parse("2015-09-26 09:00:00"),
-                    formatter.parse("2015-09-26 13:00:00"),
-                    "SAC Mainroom", "We be talkin about stuff", superAndBatList);
-
-            ArrayList<ScheduleEvent> secondList = new ArrayList<>();
-            secondList.add(superman0);
-            secondList.add(superbat0);
-            ScheduleCluster secondCluster = new ScheduleCluster(0, "9:00 AM", secondList);
-
-            scheduleList.add(firstCluster);
-            scheduleList.add(secondCluster);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-    }
-
     class ScheduleDataAsyncTask extends AsyncTask<String, String, Void> {
 
         private ProgressDialog progressDialog = new ProgressDialog(getActivity());
-        InputStream inputStream = null;
-        String result = "";
+        JSONArray jsonArray = null;
 
         protected void onPreExecute() {
             progressDialog.setMessage("Getting schedule...");
@@ -152,7 +96,6 @@ public class ScheduleDayFragment extends Fragment {
 
             String url = "http://texasgamer.me/projects/hacktx/schedule.json";
             InputStream is = null;
-            JSONArray jsonArray = null;
             String json = "";
 
             try {
@@ -195,6 +138,58 @@ public class ScheduleDayFragment extends Fragment {
         }
 
         protected void onPostExecute(Void v) {
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+            try {
+                for (int x = 0; x < jsonArray.length(); x++) {
+                    JSONObject schedClusterJson = jsonArray.getJSONObject(x);
+                    JSONArray eventsArrayJson = schedClusterJson.getJSONArray("eventsList");
+                    ArrayList<ScheduleEvent> events = new ArrayList<>();
+
+                    for (int n = 0; n < eventsArrayJson.length(); n++) {
+                        JSONObject event = eventsArrayJson.getJSONObject(x);
+                        EventType type;
+                        switch (event.getString("type")) {
+                            case "food":
+                                type = EventType.FOOD;
+                                break;
+                            case "education":
+                                type = EventType.EDUCATION;
+                                break;
+                            case "talk":
+                                type = EventType.TALK;
+                                break;
+                            default:
+                                type = EventType.TALK;
+                                break;
+                        }
+
+                        ArrayList<ScheduleSpeaker> speakers = new ArrayList<>();
+                        JSONArray speakerArray = event.getJSONArray("speakerList");
+                        for (int k = 0; k < speakerArray.length(); k++) {
+                            JSONObject speaker = speakerArray.getJSONObject(k);
+                            speakers.add(new ScheduleSpeaker(speaker.getInt("id"), speaker.getString("name"),
+                                    speaker.getString("organization"), speaker.getString("description"),
+                                    speaker.getString("imageUrl")));
+                        }
+
+                        events.add(new ScheduleEvent(event.getInt("id"), type, event.getString("name"),
+                                formatter.parse(event.getString("startDate")),
+                                formatter.parse(event.getString("endDate")),
+                                event.getString("location"), event.getString("description"), speakers));
+                    }
+
+                    scheduleList.add(new ScheduleCluster(schedClusterJson.getInt("id"),
+                            schedClusterJson.getString("name"), events));
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+
+            RecyclerView.Adapter scheduleAdapter = new ScheduleClusterRecyclerView(scheduleList);
+            recyclerView.setAdapter(scheduleAdapter);
+
             progressDialog.dismiss();
         }
     }

--- a/app/src/main/java/hacktx/hacktx2015/models/ScheduleEvent.java
+++ b/app/src/main/java/hacktx/hacktx2015/models/ScheduleEvent.java
@@ -1,6 +1,7 @@
 package hacktx.hacktx2015.models;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 
 import hacktx.hacktx2015.enums.EventType;
@@ -13,8 +14,8 @@ public class ScheduleEvent {
     private EventType type;
     private String name;
     //2001-07-04 12:08:56
-    private Date startTime;
-    private Date endTime;
+    private Calendar startTime;
+    private Calendar endTime;
     private String location;
     private String description;
     private ArrayList<ScheduleSpeaker> speakerList;
@@ -23,8 +24,10 @@ public class ScheduleEvent {
         this.id = id;
         this.type = type;
         this.name = name;
-        this.startTime = startTime;
-        this.endTime = endTime;
+        this.startTime = Calendar.getInstance();
+        this.startTime.setTime(startTime);
+        this.endTime = Calendar.getInstance();
+        this.endTime.setTime(endTime);
         this.location = location;
         this.description = description;
         this.speakerList = speakerList;
@@ -54,19 +57,19 @@ public class ScheduleEvent {
         this.name = name;
     }
 
-    public Date getStartTime() {
+    public Calendar getStartTime() {
         return startTime;
     }
 
-    public void setStartTime(Date startTime) {
+    public void setStartTime(Calendar startTime) {
         this.startTime = startTime;
     }
 
-    public Date getEndTime() {
+    public Calendar getEndTime() {
         return endTime;
     }
 
-    public void setEndTime(Date endTime) {
+    public void setEndTime(Calendar endTime) {
         this.endTime = endTime;
     }
 
@@ -95,6 +98,15 @@ public class ScheduleEvent {
     }
 
     public String getEventDetails() {
-        return "" + (getStartTime().getHours()) + ":" + (getStartTime().getMinutes()) +  " - " + (getEndTime().getHours()) + ":" + (getEndTime().getMinutes()) +  " | " + getLocation();
+        String startAmPm = "", endAmPm = "";
+        if(getStartTime().get(Calendar.AM_PM) != getEndTime().get(Calendar.AM_PM)) {
+            startAmPm = (getStartTime().get(Calendar.AM_PM) == 0) ? " AM" : " PM";
+            endAmPm = (getEndTime().get(Calendar.AM_PM) == 0) ? " AM" : " PM";
+        }
+
+        return String.format("%01d:%02d", getStartTime().get(Calendar.HOUR), getStartTime().get(Calendar.MINUTE))
+                + startAmPm + " - "
+                + String.format("%01d:%02d", getEndTime().get(Calendar.HOUR), getEndTime().get(Calendar.MINUTE))
+                + endAmPm + " | " + getLocation();
     }
 }

--- a/app/src/main/res/layout/fragment_schedule_day.xml
+++ b/app/src/main/res/layout/fragment_schedule_day.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.RecyclerView
+<android.support.v4.widget.SwipeRefreshLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/scheduleRecyclerView"
+    android:id="@+id/swipeRefreshLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/scheduleRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</android.support.v4.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/schedule_eventview.xml
+++ b/app/src/main/res/layout/schedule_eventview.xml
@@ -3,12 +3,13 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="10dp">
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
 
     <ImageView
         android:id="@+id/eventIcon"
-        android:paddingRight="20dp"
-        android:paddingLeft="20dp"
+        android:paddingRight="24dp"
+        android:paddingLeft="24dp"
         android:src="@drawable/ic_event"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
@@ -26,7 +27,7 @@
             android:textStyle="bold"/>
         <TextView
             android:id="@+id/eventDetails"
-            android:paddingTop="5dp"
+            android:paddingTop="2dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="12:30 AM - 1:00 PM | Lounge Talk (L2)"

--- a/app/src/main/res/layout/schedule_groupview.xml
+++ b/app/src/main/res/layout/schedule_groupview.xml
@@ -3,22 +3,22 @@
     android:layout_width="match_parent" android:layout_height="wrap_content">
     <TextView
         android:id="@+id/eventGroupTitle"
-        android:paddingTop="15dp"
-        android:paddingBottom="15dp"
-        android:paddingRight="50dp"
-        android:paddingLeft="50dp"
+        android:paddingTop="24dp"
+        android:paddingBottom="8dp"
+        android:paddingLeft="38dp"
+        android:paddingRight="48dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="9:30 AM"
         android:textSize="20sp"/>
+
     <LinearLayout
         android:id="@+id/eventHolderLayout"
         android:layout_below="@+id/eventGroupTitle"
-        android:padding="15dp"
+        android:paddingLeft="12dp"
+        android:paddingRight="12dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
-
     </LinearLayout>
-
 </RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,7 @@
 <resources>
     <color name="window_background">#FFF5F5F5</color>
     <color name="hacktx_white">#FEF0D9</color>
+    <color name="primary">#0AA6B6</color>
+    <color name="primaryDark">#0d8397</color>
+    <color name="accent">#F0514D</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,9 +2,9 @@
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="colorPrimary">#0AA6B6</item>
-        <item name="colorPrimaryDark">#0d8397</item>
-        <item name="colorAccent">#F0514D</item>
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primaryDark</item>
+        <item name="colorAccent">@color/accent</item>
         <item name="android:windowBackground">@color/window_background</item>
     </style>
 


### PR DESCRIPTION
* Load [mock schedule](http://texasgamer.me/projects/hacktx/schedule.json) from JSON
* Added swipe to refresh
* Cache schedule for 1 hour or until user refreshes
* Tweaked schedule time to show two digits for time when `minutes < 10`
* Adopted `Calendar` for timekeeping instead of deprecated `Date`
* Show AM/PM labels if an event takes place around noon or midnight
* Chanced recents color (API 21+) to `primaryDark` to allow for app name to be displayed in white
* Cleared history stack when navigating between sections to get proper back button behavior
* Tweaked schedule layout to tighten up view and more closely match Material Design [keylines](https://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing)